### PR TITLE
PNGWriter bug fix

### DIFF
--- a/skoolkit/pngwriter.py
+++ b/skoolkit/pngwriter.py
@@ -742,7 +742,9 @@ class PngWriter:
             for i in range(8):
                 scanline = bytearray((0,))
                 for udg in row:
-                    byte = udg.data[i] ^ (attr_map[udg.attr & 127][0] * 255)
+                    ink_bits = udg.data[i] & (attr_map[udg.attr & 127][1] * 255)
+                    paper_bits = udg.data[i] ^ 255 & (attr_map[udg.attr & 127][0] * 255)
+                    byte = ink_bits | paper_bits
                     if scale == 1:
                         scanline.append(byte)
                         continue

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -505,6 +505,15 @@ class ImageWriterTest:
         self._test_image(udg_array, scale=2)
         return udg_array
 
+    def test_unmasked_bd1_scaled_two_attributes(self):
+        # Unmasked image, bit depth 1, scales 1-2, 2 UDGs, 2 attributes using same colour
+        udg1 = Udg(4, (255, 0,) * 4)
+        udg2 = Udg(36, (255, 0,) * 4)
+        udg_array = [[udg1], [udg2]]
+        self._test_image(udg_array)
+        self._test_image(udg_array, scale=2)
+        return udg_array
+
     def test_unmasked_bd2_cropped(self):
         # Unmasked image, bit depth 2, cropped
         udg1 = Udg(30, (170,) * 8)


### PR DESCRIPTION
Hello Richard,

I recently encountered a bug in SkoolKit. I thought it would be a good exercise for me to try to fix it myself, hence this pull request. I've kept the changes in a separate branch, which contains the change to the PNGWriter class, as well as a new unit test.

I believe the problem was in the method "_build_image_data_bd1_nt", and manifested when generating a PNG with a bit depth of one from a source UDG array that used two (or more) different attributes yet the same two colours.

This bug came up when I attempted to create a PNG image from a set of UDGs, some of which had an attribute of 4 (green ink, black paper) while others had an attribute of 36 (green ink, green paper).

Old code:
    byte = udg.data[i] ^ (attr_map[udg.attr & 127][0] * 255)

This line seems to assume that the ink and paper colours are always different, however this is not necessarily true. For example, in the case where the udg.data[i] evaluates to 255 (all bits designated as ink) and the attribute used has ink and paper colours the same, the XOR operation will reset all bits on assignment to "byte" when in fact they should remain set.

The following image shows the result of generating a PNG based upon two UDGs, both with alternating data lines of 255 and 0. The attribute of the one on the left is 4, and the attribute of the one on the right is 36:

![old](https://cloud.githubusercontent.com/assets/8810509/12080002/aa33e37e-b244-11e5-9f40-3b25836e2a7b.png)

New code:
    ink_bits = udg.data[i] & (attr_map[udg.attr & 127][1] * 255)
    paper_bits = udg.data[i] ^ 255 & (attr_map[udg.attr & 127][0] * 255)
    byte = ink_bits | paper_bits

This updated code takes into account the case where ink and paper colours are the same.

The following image is generated using this fixed code, operating on the same two UDGs as the previous image:

![new](https://cloud.githubusercontent.com/assets/8810509/12080018/0f43e34a-b245-11e5-81ec-e1fc09d37d6d.png)

The GIFWriter class was unaffected, and does not appear to be afflicted with this bug.

I hope this all makes sense.

Regards,
Philip.