### PR TITLE
Skool parser ensure to keep first character of comments

### DIFF
--- a/skoolkit/skoolctl.py
+++ b/skoolkit/skoolctl.py
@@ -450,7 +450,11 @@ class SkoolParser:
         for line in skoolfile:
             if line.startswith(';'):
                 if self.mode.include:
-                    comments.append(line[2:].rstrip())
+                    if line.startswith('; '):
+                        start_from = 2
+                    else:
+                        start_from = 1
+                    comments.append(line[start_from:].rstrip())
                 instruction = None
                 address_comments.append((None, None))
                 continue

--- a/skoolkit/skoolparser.py
+++ b/skoolkit/skoolparser.py
@@ -309,7 +309,11 @@ class SkoolParser:
         for line in skoolfile:
             if line.startswith(';'):
                 if self.mode.started and self.mode.include:
-                    self.comments.append(line[2:].rstrip())
+                    if line.startswith('; '):
+                        start_from = 2
+                    else:
+                        start_from = 1
+                    self.comments.append(line[start_from:].rstrip())
                     self.mode.ignoreua = False
                 instruction = None
                 address_comments.append((None, None))


### PR DESCRIPTION
In a line that starts with a comment, if the user don't put a space
between ';' and the text, the first character is lost.