### PR TITLE
Make the behaviour of push_snapshot match its description

### DIFF
--- a/skoolkit/skoolhtml.py
+++ b/skoolkit/skoolhtml.py
@@ -450,7 +450,8 @@ class HtmlWriter:
 
         :param name: An optional name for the snapshot.
         """
-        self._snapshots.append((self.snapshot[:], name))
+        self._snapshots.append((self.snapshot, name))
+        self.snapshot = self.snapshot[:]
 
     def get_page_ids(self):
         return self.page_ids


### PR DESCRIPTION
The behaviour of the _push_snapshot_  method on HtmlWriter does not match that method's description. The description states:

> Save the current memory snapshot for later retrieval (by pop_snapshot()), and put a copy in its place.

In fact, a _copy_ of the snapshot was saved and the original was left in place. This causes issues in situations where a reference to the original snapshot was passed onto instances of other classes inside (an extended) HtmlWriter; those other classes also see any modifications made to the snapshot after pushing.

This pull request alters the method's behaviour so that it matches the description.